### PR TITLE
usage of a non-sanitized

### DIFF
--- a/App/Controller/HomeController.php
+++ b/App/Controller/HomeController.php
@@ -21,36 +21,34 @@ class HomeController
     }
     private function getAlert()
     {
-        if(isset($_GET['success']) || isset($_GET['error'])){
-            if(isset($_GET['success'])){
+        $getSuccess = filter_input(INPUT_GET, 'success', FILTER_SANITIZE_STRING);
+        $getError = filter_input(INPUT_GET, 'error', FILTER_SANITIZE_STRING);
+        if(isset($getSuccess) || isset($getError)){
+            if(isset($getSuccess)){
                 $success = new Success();
-                $function = htmlspecialchars($_GET['success'], ENT_QUOTES);
 
-                if(method_exists($success, $function) == true){
-                    $successAlert = $success->$function();
+                if(method_exists($success, $getSuccess) == true){
+                    $successAlert = $success->$getSuccess();
 
                     return $successAlert;
                 }
                 else{
                     $error = new Error();
-                    $function = "notAllowed";
-                    $errorAlert = $error->$function();
-
+                    $getSuccess = "notAllowed";
+                    $errorAlert = $error->$getSuccess();
                     return $errorAlert;
                 }
-
             }
             else{
                 $error = new Error();
-                $function = htmlspecialchars($_GET['error'], ENT_QUOTES);
 
-                if(method_exists($error, $function) == true){
-                    $errorAlert = $error->$function();
+                if(method_exists($error, $getError) == true){
+                    $errorAlert = $error->$getError();
                     return $errorAlert;
                 }
                 else{
-                    $function = "notAllowed";
-                    $errorAlert = $error->$function();
+                    $getError = "notAllowed";
+                    $errorAlert = $error->$getError();
 
                     return $errorAlert;
                 }

--- a/router.php
+++ b/router.php
@@ -29,12 +29,13 @@ class Router
 
     public function parseUrl()
     {
+        $getAccess = filter_input(INPUT_GET, 'access', FILTER_SANITIZE_STRING);
 
-        if(!isset($_GET['access'])){
-            $_GET['access'] = 'home';
+        if(!isset($getAccess)){
+            $getAccess = 'home';
         }
 
-        $this->page = $_GET['access'];
+        $this->page = $getAccess;
 
         // Cuts this page value with the exclamation point
         $access = explode('!', $this->page);


### PR DESCRIPTION
Detected usage of a non-sanitized input variable: $_GET
&
Direct use of $_GET Superglobal detected.
Use filter_input in order to save the error